### PR TITLE
Fixing broken link for starting the services

### DIFF
--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -20,7 +20,7 @@ You can do it via this Ansible playbook (make sure to edit the `<your-username>`
 ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=<your-username> password=<your-password> admin=<yes|no>' --tags=register-user
 ```
 
-**or** using the command-line after **SSH**-ing to your server (requires that [all services have been started](#starting-the-services)):
+**or** using the command-line after **SSH**-ing to your server (requires that [all services have been started](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/installing.md#3-starting-the-services)):
 
 ```
 /usr/local/bin/matrix-synapse-register-user <your-username> <your-password> <admin access: 0 or 1>


### PR DESCRIPTION
The link must go to the "Installing" page rather than the current page.

For the link I used an absolute URL https://.../blob/master/docs/installing.md#3-starting-the-services because we are inside github but for an end-user the URL should be https://.../tree/master/docs/installing.md#3-starting-the-services so I am not sure if the github merge mechanism will change it properly.

Another way to do it would be to use a relative link : ../installing.md#3-starting-the-services